### PR TITLE
chore(news): tighten the feed health check and clear the Node 20 warnings

### DIFF
--- a/.github/workflows/news-refresh.yml
+++ b/.github/workflows/news-refresh.yml
@@ -27,10 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '18'
           cache: 'npm'
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Dependency Review
         uses: actions/dependency-review-action@v4

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -24,10 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: npm

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 .aider*
 .env
 .gstack/
+.playwright-mcp/

--- a/client/scripts/fetch-rss.mjs
+++ b/client/scripts/fetch-rss.mjs
@@ -153,7 +153,9 @@ const missingSources = FEEDS.map(({ source }, i) => {
   if (shipped.has(source)) return null
   const result = settled[i]
   if (result.status === 'rejected') return `${source} (fetch failed)`
-  return `${source} (${result.value.length ? `nothing newer than ${MAX_AGE_DAYS}d` : 'empty feed'})`
+  if (!result.value.length) return `${source} (empty feed)`
+  const hasRecent = result.value.some((item) => timeOf(item) >= cutoff)
+  return `${source} (${hasRecent ? 'items excluded from snapshot' : `nothing newer than ${MAX_AGE_DAYS}d`})`
 }).filter(Boolean)
 const newestAgeHours = items.length ? (Date.now() - timeOf(items[0])) / 3_600_000 : Infinity
 

--- a/client/scripts/fetch-rss.mjs
+++ b/client/scripts/fetch-rss.mjs
@@ -35,6 +35,12 @@ const STRICT = process.argv.includes('--strict')
 const OUT_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'public', 'data')
 const OUT_FILE = path.join(OUT_DIR, 'rss.json')
 
+const cutoff = Date.now() - MAX_AGE_DAYS * 24 * 60 * 60 * 1000
+const timeOf = (item) => {
+  const parsed = Date.parse(item.pubDate) // handles both RFC-822 (RSS) and ISO-8601 (Atom)
+  return Number.isNaN(parsed) ? 0 : parsed
+}
+
 const parser = new XMLParser({
   ignoreAttributes: false,
   attributeNamePrefix: '@_',
@@ -105,13 +111,11 @@ async function fetchFeed({ url, source, max }) {
     },
   })
   if (!res.ok) throw new Error(`HTTP ${res.status}`)
-  return parseFeed(await res.text(), source).slice(0, max)
-}
-
-const cutoff = Date.now() - MAX_AGE_DAYS * 24 * 60 * 60 * 1000
-const timeOf = (item) => {
-  const parsed = Date.parse(item.pubDate) // handles both RFC-822 (RSS) and ISO-8601 (Atom)
-  return Number.isNaN(parsed) ? 0 : parsed
+  // Sort before capping: newest-first is only a convention, and `max` silently keeps
+  // whatever happens to be at the top of the document.
+  return parseFeed(await res.text(), source)
+    .sort((a, b) => timeOf(b) - timeOf(a))
+    .slice(0, max)
 }
 
 const settled = await Promise.allSettled(FEEDS.map(fetchFeed))
@@ -140,16 +144,23 @@ writeFileSync(OUT_FILE, JSON.stringify(items, null, 2))
 // Write the snapshot first: even a degraded one beats none, and --strict must not
 // cost the site its feed on the way out.
 
-const failedSources = settled
-  .map((result, i) => (result.status === 'fulfilled' && result.value.length ? null : FEEDS[i].source))
-  .filter(Boolean)
-const healthyCount = FEEDS.length - failedSources.length
+// Health is measured on what SHIPPED, not on what fetched. A feed can return 200 with
+// items that are all months old — it contributes nothing to the page while looking fine
+// at the fetch layer. That gap is precisely how the old Nasdaq source stayed unnoticed.
+const shipped = new Set(items.map((item) => item.source))
+const healthyCount = shipped.size
+const missingSources = FEEDS.map(({ source }, i) => {
+  if (shipped.has(source)) return null
+  const result = settled[i]
+  if (result.status === 'rejected') return `${source} (fetch failed)`
+  return `${source} (${result.value.length ? `nothing newer than ${MAX_AGE_DAYS}d` : 'empty feed'})`
+}).filter(Boolean)
 const newestAgeHours = items.length ? (Date.now() - timeOf(items[0])) / 3_600_000 : Infinity
 
 const problems = []
 if (healthyCount < MIN_HEALTHY_SOURCES) {
   problems.push(
-    `only ${healthyCount}/${FEEDS.length} sources returned items (need ${MIN_HEALTHY_SOURCES}); down: ${failedSources.join(', ')}`,
+    `only ${healthyCount}/${FEEDS.length} sources reached the snapshot (need ${MIN_HEALTHY_SOURCES}); missing: ${missingSources.join(', ')}`,
   )
 }
 if (newestAgeHours > MAX_NEWEST_AGE_HOURS) {
@@ -157,8 +168,8 @@ if (newestAgeHours > MAX_NEWEST_AGE_HOURS) {
   problems.push(`newest item is ${age} (expected under ${MAX_NEWEST_AGE_HOURS}h) — feeds may be reachable but stale`)
 }
 
-const summary = `fetch-rss: ${items.length} items, ${healthyCount}/${FEEDS.length} sources healthy${
-  failedSources.length ? ` (down: ${failedSources.join(', ')})` : ''
+const summary = `fetch-rss: ${items.length} items, ${healthyCount}/${FEEDS.length} sources in snapshot${
+  missingSources.length ? ` (missing: ${missingSources.join(', ')})` : ''
 }`
 console.log(summary)
 


### PR DESCRIPTION
Cleanup pass over the RSS feed work from this session. No new features, no new sources.

## Health is measured on the wrong thing

`fetch-rss.mjs` counted a source healthy if the fetch succeeded. A feed can return HTTP 200 with items that are all months old — it contributes nothing to the page while looking fine at the fetch layer. That is the exact gap that let the old Nasdaq source sit stale for two weeks without anything noticing, so a health check that reproduces it is not much of a check.

Health now counts sources that actually reached the snapshot. VentureBeat makes the case concrete: 7 items spanning 219 days, so it can plausibly fetch clean and ship nothing.

Missing sources now say why, which is the difference between an alert you can act on and one you have to go investigate:

```
fetch-rss: 3 items, 1/7 sources in snapshot (missing: The Guardian (nothing newer than 1d),
Ars Technica (nothing newer than 1d), The Verge (nothing newer than 1d), ...)
```

Worth knowing before merge: this **will** fire if a legitimately slow publisher goes quiet past the 30-day window. That is signal rather than noise — a source contributing nothing is the failure this was built to catch, and the fix is to swap the source.

## Sort each feed before capping it

`slice(0, max)` took whatever sat at the top of the document. Every one of the seven publishers emits newest-first, so this was correct — by convention, not by construction. Now it sorts on the dates first.

Verified: all 7 feeds are sorted newest-first today, and the regenerated `rss.json` is byte-identical. Behaviour only changes the day a publisher pins or reorders a post.

## Node 20 deprecation

`actions/checkout` and `actions/setup-node` v4 → v5 across `static.yml`, `news-refresh.yml` and `security-scan.yml`. Both v5s are already proven on this repo — `feed-health.yml` has run green on them.

**Not done here, on purpose:** the Pages deploy chain (`configure-pages@v5`, `deploy-pages@v4`, `upload-pages-artifact@v3`) is still on Node 20 and will keep warning. Those sit directly on the path that publishes the live site, and their latest majors are two to three versions ahead. That belongs in its own PR where a failure is unambiguous instead of tangled up in a cleanup diff.

## Also

- `.gitignore` now covers `.playwright-mcp/` — tool output that was dirtying `git status`.

## Verification

Every path exercised locally, failure branches included:

| Case | Deploy path (no `--strict`) | Health job (`--strict`) |
|---|---|---|
| 7/7 healthy | exit 0 | exit 0 |
| 3 sources dead | exit 0 + `::error::` annotation | exit 1 |
| Reachable but nothing recent | exit 0 + annotation naming each source | exit 1 |

Deploys stay green throughout — a publisher outage must never block shipping content. `npm run build` and `oxlint` pass; all four workflow files parse.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * News items are now ordered newest first, making recent stories easier to find.
  * News health reporting now distinguishes unavailable, empty, and outdated feeds and identifies missing sources.

* **Bug Fixes**
  * Improved feed processing ensures source limits retain the most recent articles.

* **Chores**
  * Updated automated workflows for improved reliability.
  * Added generated Playwright artifacts to ignored files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->